### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Net/SOCKS.pm6
+++ b/lib/Net/SOCKS.pm6
@@ -1,4 +1,4 @@
-class Net::SOCKS;
+unit class Net::SOCKS;
 
 method connect(:$host!, :$port!, :$proxy-server, :$proxy-port = 1080, :$socket = IO::Socket::INET) {
     my $request = Buf.new(0x05, # version 5


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
