### PR TITLE
Add `use experimental :pack`

### DIFF
--- a/lib/Net/SOCKS.pm6
+++ b/lib/Net/SOCKS.pm6
@@ -1,5 +1,7 @@
 unit class Net::SOCKS;
 
+use experimental :pack;
+
 method connect(:$host!, :$port!, :$proxy-server, :$proxy-port = 1080, :$socket = IO::Socket::INET) {
     my $request = Buf.new(0x05, # version 5
                           0x01, # one auth method


### PR DESCRIPTION
SOCKS.pm6 is using experimental pack/unpack rakudo feature which
needs to be enabled with a pragma. Rakudo versions ≤ 2018.05 used to
give a run time error on first use, but starting with 2018.06 it will
be a compile time error. Tests were never hitting the lines
with `pack` which is why they were green previously.